### PR TITLE
Add get Pose2d/Pose3d to NTUtills

### DIFF
--- a/src/main/java/org/jmhsrobotics/warcore/nt/NT4Util.java
+++ b/src/main/java/org/jmhsrobotics/warcore/nt/NT4Util.java
@@ -2,6 +2,9 @@ package org.jmhsrobotics.warcore.nt;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Quaternion;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
@@ -13,7 +16,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 public class NT4Util {
 
 	/**
-	 * Put a Pose3d array in the table.
+	 * Put a Pose3d array into Network Tables
 	 *
 	 * @param key
 	 *            the key to be assigned to
@@ -36,7 +39,7 @@ public class NT4Util {
 	}
 
 	/**
-	 * Put a Pose2d array in the table
+	 * Put a Pose2d array into Network Tables
 	 *
 	 * @param key
 	 *            the key to be assigned to
@@ -58,10 +61,12 @@ public class NT4Util {
 	}
 
 	/**
-	 * Put a Trajectory into a table
+	 * Put a Trajectory into Network Tables
 	 *
 	 * @param key
+	 *            the key to be assigned to
 	 * @param value
+	 *            the value that will be assigned
 	 * @return False if the table key already exists with a different type
 	 */
 	public static boolean putTrajectory(String key, Trajectory value) {
@@ -78,5 +83,67 @@ public class NT4Util {
 		}
 
 		return SmartDashboard.putNumberArray(key, data);
+	}
+
+	/**
+	 * Get Pose2d array from Network Tables
+	 *
+	 * @param key
+	 *            the key to be retrieved
+	 * @return Pose2d array
+	 */
+	public static Pose2d[] getPose2ds(String key) {
+		double[] data = SmartDashboard.getNumberArray(key, new double[0]);
+
+		if (data.length % 3 != 0) {
+			throw new IllegalArgumentException("Invalid Data format");
+		}
+
+		int numPoses = data.length / 3;
+		Pose2d[] poses = new Pose2d[numPoses];
+
+		int ndx = 0;
+		for (int i = 0; i < numPoses; i++) {
+			double x = data[ndx];
+			double y = data[ndx + 1];
+			double rotationDegrees = data[ndx + 2];
+			poses[i] = new Pose2d(x, y, Rotation2d.fromDegrees(rotationDegrees));
+			ndx += 3;
+		}
+
+		return poses;
+	}
+
+	/**
+	 * Get Pose3d array from Network Tables
+	 *
+	 * @param key
+	 *            the key to be retrieved
+	 * @return Pose3d array
+	 */
+	public static Pose3d[] getPose3ds(String key) {
+		double[] data = SmartDashboard.getNumberArray(key, new double[0]);
+
+		if (data.length % 7 != 0) {
+			throw new IllegalArgumentException("Invalid Data format");
+		}
+
+		int numPoses = data.length / 7;
+		Pose3d[] poses = new Pose3d[numPoses];
+
+		int ndx = 0;
+		for (int i = 0; i < numPoses; i++) {
+			double x = data[ndx];
+			double y = data[ndx + 1];
+			double z = data[ndx + 2];
+			double qw = data[ndx + 3];
+			double qx = data[ndx + 4];
+			double qy = data[ndx + 5];
+			double qz = data[ndx + 6];
+			poses[i] = new Pose3d(x, y, z, new Rotation3d(new Quaternion(qw, qx, qy, qz)));
+			ndx += 7;
+		}
+
+		return poses;
 	}
 }


### PR DESCRIPTION
Add methods to construct pose2d/pose3d objects from network tables. Getting trajectories are not not possible because only position and rotations are published to NT and not time. 